### PR TITLE
PEN-653 upgrade TwilioVideo to ~> 4.1 for ios

### DIFF
--- a/Example/ios/Example.xcodeproj/project.pbxproj
+++ b/Example/ios/Example.xcodeproj/project.pbxproj
@@ -975,7 +975,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-frameworks.sh",
-				"${PODS_ROOT}/TwilioVideo/Build/iOS/TwilioVideo.framework",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/TwilioVideo/TwilioVideo.framework/TwilioVideo",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/Example/ios/Example.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/ios/Example.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -8,9 +8,9 @@ PODS:
   - glog (0.3.4)
   - React (0.59.9):
     - React/Core (= 0.59.9)
-  - react-native-twilio-video-webrtc (1.0.2-1):
+  - react-native-twilio-video-webrtc (2.0.0):
     - React
-    - TwilioVideo (~> 3.7)
+    - TwilioVideo (~> 4.1)
   - React/Core (0.59.9):
     - yoga (= 0.59.9.React)
   - React/CxxBridge (0.59.9):
@@ -35,7 +35,7 @@ PODS:
     - React/cxxreact
     - React/jsi
   - React/jsinspector (0.59.9)
-  - TwilioVideo (3.7.1)
+  - TwilioVideo (4.1.0)
   - yoga (0.59.9.React)
 
 DEPENDENCIES:
@@ -68,8 +68,8 @@ SPEC CHECKSUMS:
   Folly: de497beb10f102453a1afa9edbf8cf8a251890de
   glog: 1de0bb937dccdc981596d3b5825ebfb765017ded
   React: a86b92f00edbe1873a63e4a212c29b7a7ad5224f
-  react-native-twilio-video-webrtc: c33953a98c71b8600ba321e01f52c62e0c20ab6e
-  TwilioVideo: 807526f68043a11f0e17e5c26ef0f0f73d5678e4
+  react-native-twilio-video-webrtc: 5b40ee0129687cb89fb5055680aed35c8db4be07
+  TwilioVideo: 17bfe3dcac945c6c1235c4584dc37e07a28ccb61
   yoga: 03ff42a6f223fb88deeaed60249020d80c3091ee
 
 PODFILE CHECKSUM: a22eec28b45c6a20b9c752a17cdef0f608e13c10

--- a/react-native-twilio-video-webrtc.podspec
+++ b/react-native-twilio-video-webrtc.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'TwilioVideo', '~> 3.7'
+  s.dependency 'TwilioVideo', '~> 4.1'
 end


### PR DESCRIPTION
**Purpose**
Update the twilio video library from 3.7.1 -> 4.1.0

***Context***
We have a p0 issue in PHX with degraded video on ios devices.

We are using an older version of the twilio video SDK. And we need to ensure the iOS and android SDKs are appropriately updated to >= 4.0.0.

@Ayyzee and I reviewed the [Migration Notes](https://www.twilio.com/docs/video/migrating-3x-4x-ios) and didn't see anything that might affect us, after reviewing the source code for this wrapper.